### PR TITLE
K8s Api updates

### DIFF
--- a/pkg/resource/cronjob.go
+++ b/pkg/resource/cronjob.go
@@ -3,7 +3,7 @@ package resource
 import (
 	"k8s-event-listener/pkg/eventlistener"
 
-	"k8s.io/api/batch/v1beta1"
+	v1 "k8s.io/api/batch/v1"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -20,15 +20,15 @@ func getCronjob() resourceType {
 			r = &eventlistener.Resource{}
 			r.ResourceName = "cronjobs"
 			r.RestClient = func(clientset *kubernetes.Clientset) rest.Interface {
-				return clientset.BatchV1beta1().RESTClient()
+				return clientset.BatchV1().RESTClient()
 			}
-			r.ResourceType = &v1beta1.CronJob{}
+			r.ResourceType = &v1.CronJob{}
 			r.Callback = createCallbackFn(
 				callback,
 				r.ResourceName,
 				func(obj interface{}, meta *callBackMeta) {
 					if obj != nil {
-						objType := obj.(*v1beta1.CronJob)
+						objType := obj.(*v1.CronJob)
 						meta.namespace = objType.GetNamespace()
 						meta.name = objType.GetName()
 					}

--- a/pkg/resource/ingress.go
+++ b/pkg/resource/ingress.go
@@ -3,7 +3,7 @@ package resource
 import (
 	"k8s-event-listener/pkg/eventlistener"
 
-	"k8s.io/api/networking/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -19,15 +19,15 @@ func getIngress() resourceType {
 			r = &eventlistener.Resource{}
 			r.ResourceName = "ingresses"
 			r.RestClient = func(clientset *kubernetes.Clientset) rest.Interface {
-				return clientset.NetworkingV1beta1().RESTClient()
+				return clientset.NetworkingV1().RESTClient()
 			}
-			r.ResourceType = &v1beta1.Ingress{}
+			r.ResourceType = &v1.Ingress{}
 			r.Callback = createCallbackFn(
 				callback,
 				r.ResourceName,
 				func(obj interface{}, meta *callBackMeta) {
 					if obj != nil {
-						objType := obj.(*v1beta1.Ingress)
+						objType := obj.(*v1.Ingress)
 						meta.namespace = objType.GetNamespace()
 						meta.name = objType.GetName()
 					}


### PR DESCRIPTION
Move from batch/v1beta1 to batch/v1 api.
Move from networking/v1beta1 to networking/v1 api.

These are also deprecated/removed in recent K8s versions: https://kubernetes.io/docs/reference/using-api/deprecation-guide/ 